### PR TITLE
Update SeachController.swift to use https

### DIFF
--- a/Flashcards/SearchController.swift
+++ b/Flashcards/SearchController.swift
@@ -11,7 +11,7 @@ class SearchController: UIViewController {
     
     @IBOutlet weak var webView: UIWebView!
     var flashcard: Flashcard?
-    let baseSearchURL = "http://google.com/search?q=apple developer"
+    let baseSearchURL = "https://google.com/search?q=apple developer"
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
Changed:
let baseSearchURL = "http://google.com/search?q=apple developer" to let baseSearchURL = "https://google.com/search?q=apple developer"

Change made in order to make use of Apple's App Transport Security (ATS) which is enabled by default in iOS9 apps. This change prevents the Xcode debug message: "App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file."

https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33
